### PR TITLE
Support for sbt > 0.13.9

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -174,7 +174,7 @@ get_supported_sbt_version() {
   local ctxDir=$1
   if _has_buildPropertiesFile $ctxDir; then
     sbtVersionLine="$(grep -P '[ \t]*sbt\.version[ \t]*=' "${ctxDir}"/project/build.properties | sed -E -e 's/[ \t\r\n]//g')"
-    sbtVersion=$(expr "$sbtVersionLine" : 'sbt\.version=\(0\.1[1-3]\.[0-9]\(-[a-zA-Z0-9_]*\)*\)$')
+    sbtVersion=$(expr "$sbtVersionLine" : 'sbt\.version=\(0\.1[1-3]\.[0-9]+\(-[a-zA-Z0-9_]*\)*\)$')
     if [ "$sbtVersion" != 0 ] ; then
       echo "$sbtVersion"
     else


### PR DESCRIPTION
Fixed in a slightly different way than in the heroku buildpack so that only "semver" versions are passing (right now, in the heroku buildpack `sbt.version=0.13.` is considered as valid - see commit 7a99c80cd293d4297c747e23d29c6bfdaf35b3e2 there).